### PR TITLE
Ignore IntelliJ project configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@
 .Trashes
 ehthumbs.db
 Thumbs.db
+
+# IDE project files #
+#####################
+/*.iml


### PR DESCRIPTION
Local specific IDE configuration files should stay local.