### PR TITLE
Improve performance.

### DIFF
--- a/includes/abstracts/abstract-wc-gzd-product.php
+++ b/includes/abstracts/abstract-wc-gzd-product.php
@@ -364,7 +364,7 @@ class WC_GZD_Product {
 	 */
 	public function get_delivery_time() {
 		
-		$terms = wp_get_post_terms( $this->id, 'product_delivery_time' );
+		$terms = get_the_terms( $this->id, 'product_delivery_time' );
 		
 		if ( $this->child->is_type( 'variation' ) ) {
 			$variation_terms = wp_get_post_terms( $this->child->variation_id , 'product_delivery_time' );

--- a/includes/abstracts/abstract-wc-gzd-product.php
+++ b/includes/abstracts/abstract-wc-gzd-product.php
@@ -367,7 +367,7 @@ class WC_GZD_Product {
 		$terms = get_the_terms( $this->id, 'product_delivery_time' );
 		
 		if ( $this->child->is_type( 'variation' ) ) {
-			$variation_terms = wp_get_post_terms( $this->child->variation_id , 'product_delivery_time' );
+			$variation_terms = get_the_terms( $this->child->variation_id , 'product_delivery_time' );
 			if ( ! empty( $variation_terms ) && ! is_wp_error( $variation_terms ) )
 				$terms = $variation_terms;
 		}

--- a/includes/admin/meta-boxes/class-wc-gzd-meta-box-product-data-variable.php
+++ b/includes/admin/meta-boxes/class-wc-gzd-meta-box-product-data-variable.php
@@ -73,7 +73,7 @@ class WC_Germanized_Meta_Box_Product_Data_Variable {
 			$variation_data[ $field ] = isset( $variation_meta[ $field ][0] ) ? maybe_unserialize( $variation_meta[ $field ][0] ) : $value;
 		}
 
-		$delivery_time = wp_get_post_terms( $variation_id, 'product_delivery_time' );
+		$delivery_time = get_the_terms( $variation_id, 'product_delivery_time' );
 		
 		if ( $delivery_time && ! empty( $delivery_time ) && is_array( $delivery_time ) )
 			$delivery_time = $delivery_time[0];


### PR DESCRIPTION
This pull request replaces three usages of the **uncached** API function `wp_get_object_terms()` (triggered by calling `wp_get_post_terms()`) with the **cached** template function `get_the_terms()`.

This will speed up things quite a bit as you only ever perform a query a single time, and not multiple times.

Further reading:
- [WordPress Codex - Function Reference: `wp_get_object_terms`](https://codex.wordpress.org/Function_Reference/wp_get_object_terms)
- [Use `get_the_terms()` instead of `wp_get_object_terms()`](https://www.yukei.net/2016/04/use-get_the_terms-instead-of-wp_get_object_terms/)
- many more...
