### PR TITLE
Change schema against last WooCommerce change and bug fixes

### DIFF
--- a/includes/api/class-wc-gzd-rest-api.php
+++ b/includes/api/class-wc-gzd-rest-api.php
@@ -18,21 +18,16 @@ class WC_GZD_REST_API {
 	}
 
 	private function __construct() {
-		add_action( 'woocommerce_loaded', array( $this, 'init' ) );
+		add_action( 'rest_api_init', array( $this, 'init' ) );
 	}
 
 	public function init() {
-
-		global $wp_version;
-
-		if ( version_compare( WC_GZD_Dependencies::instance()->get_plugin_version( 'woocommerce' ), '2.6', '<' ) || version_compare( $wp_version, 4.4, '<' ) )
+		if ( version_compare( WC_GZD_Dependencies::instance()->get_plugin_version( 'woocommerce' ), '2.6', '<' ) )
 			return;
 
 		$this->rest_api_includes();
-
-		// Init REST API routes.
-		add_action( 'rest_api_init', array( $this, 'register_rest_routes' ), 25 );
-
+		
+		$this->register_rest_routes();
 	}
 
 	public function rest_api_includes() {

--- a/includes/api/class-wc-gzd-rest-customers-controller.php
+++ b/includes/api/class-wc-gzd-rest-customers-controller.php
@@ -14,8 +14,6 @@ class WC_GZD_REST_Customers_Controller {
 
 	/**
 	 * ExtendOrdersController constructor.
-	 *
-	 * @param WC_Payment_Gateways $payment_gateways
 	 */
 	public function __construct() {
 		$this->direct_debit_gateway = new WC_GZD_Gateway_Direct_Debit();
@@ -29,7 +27,7 @@ class WC_GZD_REST_Customers_Controller {
 	 * Filter customer data returned from the REST API.
 	 *
 	 * @since 1.0.0
-	 * @wp-hook woocommerce_rest_prepare_order
+	 * @wp-hook woocommerce_rest_prepare_customer
 	 *
 	 * @param \WP_REST_Response $response The response object.
 	 * @param \WP_User $customer User object used to create response.
@@ -84,15 +82,17 @@ class WC_GZD_REST_Customers_Controller {
 	public function schema( $schema_properties ) {
 
 		$schema_properties['billing']['properties']['title'] = array(
-			'description' => __( 'Title', 'woocommerce-germanized-pro' ),
+			'description' => __( 'Title', 'woocommerce-germanized' ),
 			'type'        => 'integer',
-			'context'     => array( 'view', 'edit' )
+			'context'     => array( 'view', 'edit' ),
+			'enum'        => array( 1, 2 )
 		);
 
 		$schema_properties['shipping']['properties']['title'] = array(
-			'description' => __( 'Title', 'woocommerce-germanized-pro' ),
+			'description' => __( 'Title', 'woocommerce-germanized' ),
 			'type'        => 'integer',
-			'context'     => array( 'view', 'edit' )
+			'context'     => array( 'view', 'edit' ),
+			'enum'        => array( 1, 2 )
 		);
 
 		return $schema_properties;

--- a/includes/api/class-wc-gzd-rest-orders-controller.php
+++ b/includes/api/class-wc-gzd-rest-orders-controller.php
@@ -86,13 +86,15 @@ class WC_GZD_REST_Orders_Controller {
 		$schema_properties['billing']['properties']['title'] = array(
 			'description' => __( 'Title', 'woocommerce-germanized' ),
 			'type'        => 'integer',
-			'context'     => array( 'view', 'edit' )
+			'context'     => array( 'view', 'edit' ),
+			'enum'        => array( 1, 2 )
 		);
 
 		$schema_properties['shipping']['properties']['title'] = array(
 			'description' => __( 'Title', 'woocommerce-germanized' ),
 			'type'        => 'integer',
-			'context'     => array( 'view', 'edit' )
+			'context'     => array( 'view', 'edit' ),
+			'enum'        => array( 1, 2 )
 		);
 
 		$schema_properties['parcel_delivery_opted_in'] = array(
@@ -118,7 +120,7 @@ class WC_GZD_REST_Orders_Controller {
 				'update_callback' => array( $this, 'update_direct_debit' ),
 				'schema'          => array(
 					'description' => __( 'Direct Debit', 'woocommerce-germanized' ),
-					'type'        => 'array',
+					'type'        => 'object',
 					'context'     => array( 'view', 'edit' ),
 					'properties'  => array(
 						'holder'     => array(

--- a/includes/api/class-wc-gzd-rest-products-controller.php
+++ b/includes/api/class-wc-gzd-rest-products-controller.php
@@ -26,7 +26,7 @@ class WC_GZD_REST_Products_Controller {
 
 		$schema_properties['delivery_time'] = array(
 			'description' => __( 'Delivery Time', 'woocommerce-germanized' ),
-			'type'        => 'array',
+			'type'        => 'object',
 			'context'     => array( 'view', 'edit' ),
 			'properties'  => array(
 				'id' => array(
@@ -55,7 +55,7 @@ class WC_GZD_REST_Products_Controller {
 		);
 		$schema_properties['sale_price_label'] = array(
 			'description' => __( 'Price Label', 'woocommerce-germanized' ),
-			'type'        => 'array',
+			'type'        => 'object',
 			'context'     => array( 'view', 'edit' ),
 			'properties'  => array(
 				'id' => array(
@@ -78,7 +78,7 @@ class WC_GZD_REST_Products_Controller {
 		);
 		$schema_properties['sale_price_regular_label'] = array(
 			'description' => __( 'Price Label', 'woocommerce-germanized' ),
-			'type'        => 'array',
+			'type'        => 'object',
 			'context'     => array( 'view', 'edit' ),
 			'properties'  => array(
 				'id' => array(
@@ -101,7 +101,7 @@ class WC_GZD_REST_Products_Controller {
 		);
 		$schema_properties['unit'] = array(
 			'description' => __( 'Unit', 'woocommerce-germanized' ),
-			'type'        => 'array',
+			'type'        => 'object',
 			'context'     => array( 'view', 'edit' ),
 			'properties'  => array(
 				'id' => array(
@@ -124,7 +124,7 @@ class WC_GZD_REST_Products_Controller {
 		);
 		$schema_properties['unit_price'] = array(
 			'description' => __( 'Unit Price', 'woocommerce-germanized' ),
-			'type'        => 'array',
+			'type'        => 'object',
 			'context'     => array( 'view', 'edit' ),
 			'properties'  => array(
 				'base' => array(
@@ -177,9 +177,9 @@ class WC_GZD_REST_Products_Controller {
 			'default'     => false,
 			'context'     => array( 'view', 'edit' ),
 		);
-		$schema_properties['variations']['properties'][ 'delivery_time' ] = array(
+		$schema_properties['variations']['items']['properties'][ 'delivery_time' ] = array(
 			'description' => __( 'Delivery Time', 'woocommerce-germanized' ),
-			'type'        => 'array',
+			'type'        => 'object',
 			'context'     => array( 'view', 'edit' ),
 			'properties'  => array(
 				'id' => array(
@@ -206,9 +206,9 @@ class WC_GZD_REST_Products_Controller {
 				),
 			)
 		);
-		$schema_properties['variations']['properties'][ 'sale_price_label' ] = array(
+		$schema_properties['variations']['items']['properties'][ 'sale_price_label' ] = array(
 			'description' => __( 'Price Label', 'woocommerce-germanized' ),
-			'type'        => 'array',
+			'type'        => 'object',
 			'context'     => array( 'view', 'edit' ),
 			'properties'  => array(
 				'id' => array(
@@ -229,9 +229,9 @@ class WC_GZD_REST_Products_Controller {
 				)
 			)
 		);
-		$schema_properties['variations']['properties'][ 'sale_price_regular_label' ] = array(
+		$schema_properties['variations']['items']['properties'][ 'sale_price_regular_label' ] = array(
 			'description' => __( 'Price Label', 'woocommerce-germanized' ),
-			'type'        => 'array',
+			'type'        => 'object',
 			'context'     => array( 'view', 'edit' ),
 			'properties'  => array(
 				'id' => array(
@@ -252,14 +252,14 @@ class WC_GZD_REST_Products_Controller {
 				)
 			)
 		);
-		$schema_properties['variations']['properties'][ 'mini_desc' ] = array(
+		$schema_properties['variations']['items']['properties'][ 'mini_desc' ] = array(
 			'description' => __( 'Small Cart Product Description', 'woocommerce-germanized' ),
 			'type'        => 'string',
 			'context'     => array( 'view', 'edit' ),
 		);
-		$schema_properties['variations']['properties'][ 'unit_price' ] = array(
+		$schema_properties['variations']['items']['properties'][ 'unit_price' ] = array(
 			'description' => __( 'Unit Price', 'woocommerce-germanized' ),
-			'type'        => 'array',
+			'type'        => 'object',
 			'context'     => array( 'view', 'edit' ),
 			'properties'  => array(
 				'base' => array(


### PR DESCRIPTION
WooCommerce has changed the REST-API schema in 2.6.9 because of WordPress 4.7
The rest_api_init comes to late so that the germanized extend schema is not used.