### PR TITLE
Initialize variable to prevent the "Undefined variable" notice.

### DIFF
--- a/includes/class-wc-gzd-product-grouped.php
+++ b/includes/class-wc-gzd-product-grouped.php
@@ -213,6 +213,8 @@ class WC_GZD_Product_Grouped extends WC_GZD_Product {
      * @return string
      */
     public function get_unit_html( $show_sale = true ) {
+		$price = '';
+
         if ( $this->has_unit() ) {
 
             $prices        = $this->get_child_unit_prices();

--- a/includes/class-wc-gzd-product-grouped.php
+++ b/includes/class-wc-gzd-product-grouped.php
@@ -213,7 +213,7 @@ class WC_GZD_Product_Grouped extends WC_GZD_Product {
      * @return string
      */
     public function get_unit_html( $show_sale = true ) {
-		$price = '';
+	$price = '';
 
         if ( $this->has_unit() ) {
 


### PR DESCRIPTION
Hi, 
If you add the filter "woocommerce_gzd_unit_price_html" and the result of the function "has_unit" is false, you get an "Undefined variable" PHP notice.

I initialized the variable to fix the issue.

Thanks for your excellent work!