### PR TITLE
filter missing from get_formatted_product_units

### DIFF
--- a/includes/class-wc-gzd-order-item-product.php
+++ b/includes/class-wc-gzd-order-item-product.php
@@ -149,7 +149,16 @@ class WC_GZD_Order_Item_Product extends WC_GZD_Order_Item {
 			$html = wc_gzd_replace_label_shortcodes( $text, $replacements );
 		}
 
-		return $html;
+		/**
+		 * Filter to adjust the product units HTML output.
+		 *
+		 * @param string $html The HTML output.
+		 * @param WC_GZD_Order_Item_Product $order_item The order item product object.
+		 *
+		 * @since 3.1.12
+		 *
+		 */
+		return apply_filters( 'woocommerce_gzd_product_units_html', $html, $this );
 	}
 
 	public function has_unit_product() {

--- a/includes/class-wc-gzd-order-item-product.php
+++ b/includes/class-wc-gzd-order-item-product.php
@@ -158,7 +158,7 @@ class WC_GZD_Order_Item_Product extends WC_GZD_Order_Item {
 		 * @since 3.1.12
 		 *
 		 */
-		return apply_filters( 'woocommerce_gzd_product_units_html', $html, $this );
+		return apply_filters( 'woocommerce_gzd_order_item_product_units_html', $html, $this );
 	}
 
 	public function has_unit_product() {


### PR DESCRIPTION
Hi,

I noticed that since v3.1.10 my custom placeholders for "woocommerce_gzd_product_units_text" did not get replaced in emails and on the checkout page anymore.

I compared 3.1.9 and 3.1.10 and noticed the introduction of "class-wc-gzd-order-item-product.php" which also contains a function ("get_formatted_product_units") to replace the placeholder (e.g. {product_units}) like in the function "get_unit_product_html" in "abstract-wc-gzd-product.php"

but the function "get_formatted_product_units" was missing a filter like that "get_unit_product_html" uses so you could add your own placeholders (which I need to)

So I added a filter to get_formatted_product_units like in get_unit_product_html.

I named it differnetly because woocommerce_gzd_product_units_html uses a WC_GZD_Product object and woocommerce_gzd_order_item_product_units_html uses a WC_GZD_Order_Item_Product object.

Cheers,
Tobias