### PR TITLE
Account for `-1` being returned by `wc_get_page_id()`

### DIFF
--- a/includes/wc-gzd-core-functions.php
+++ b/includes/wc-gzd-core-functions.php
@@ -398,7 +398,7 @@ function wc_gzd_get_page_permalink( $type ) {
 		$page_id = wc_gzd_get_privacy_policy_page_id();
 	}
 
-	$link = $page_id ? get_permalink( $page_id ) : '';
+	$link = ( $page_id > 0 ) ? get_permalink( $page_id ) : '';
 
 	/**
 	 * Filters the page permalink for a certain legal page.


### PR DESCRIPTION
I've identified a large number of unnecessary database queries being triggered by WooCommerce Germanized, and I traced the problem to the fact that the WooCommerce function `wc_get_page_id()` can return `-1` if a given page does not exist. Germanized doesn't check for this and the result is that if some pages are not configured, for example the "Terms & Conditions" page, Germanized ultimately causes the following database query to be called repeatedly:

```sql
SELECT *
FROM wp_posts
WHERE ID = -1
LIMIT 1
```

This is because `wc_gzd_get_page_permalink()` does not expect `wc_get_page_id()` to return `-1` and therefore passes it through to `get_permalink()` which will perform a database query looking for a post with an ID of `-1`.

## Impact

On this particular client site we're seeing this unnecessary query being performed over 25 times on every page load.

## To reproduce

* Configure Germanized but don't select any pages on the WooCommerce -> Settings -> Germanized -> General screen
* Install the Query Monitor plugin for debugging purposes
* View a page and observe the unnecessary queries in the Query Monitor -> Queries panel

Results will probably differ on different sites and with a different number of pages either configured or not configured.

## Screenshot

<img width="1426" alt="" src="https://user-images.githubusercontent.com/208434/186896429-935d259d-e715-4f05-ac7b-84c5eb133407.png">
