### PR TITLE
gzd_admin: fix typo and creation of dynamic property `wizward`

### DIFF
--- a/includes/admin/class-wc-gzd-admin.php
+++ b/includes/admin/class-wc-gzd-admin.php
@@ -111,7 +111,7 @@ class WC_GZD_Admin {
 
 		add_filter( 'woocommerce_gzd_shipment_admin_provider_list', array( $this, 'maybe_register_shipping_providers' ), 10 );
 
-		$this->wizward = require 'class-wc-gzd-admin-setup-wizard.php';
+		$this->wizard = require 'class-wc-gzd-admin-setup-wizard.php';
 	}
 
 	public function tool_actions() {


### PR DESCRIPTION
- dynamic creation of $this->wizward is deprecated in PHP 8.2
- wizward seems to be a typo
- neither wizward nor wizard seems to be used anywhere (I may have just not been able to find its usage due to some "magic calling")