### PR TITLE
Use `get_price_html()` instead of `get_price()` in `hide_shopmarks_due_to_missing_price()`

### DIFF
--- a/includes/abstracts/abstract-wc-gzd-product.php
+++ b/includes/abstracts/abstract-wc-gzd-product.php
@@ -1560,7 +1560,7 @@ class WC_GZD_Product {
 			$price_html_checked = ( '' === $this->child->get_price_html() );
 		}
 
-		$has_empty_price = apply_filters( 'woocommerce_gzd_product_misses_price', ( '' === $this->get_price() && $price_html_checked ), $this );
+		$has_empty_price = apply_filters( 'woocommerce_gzd_product_misses_price', ( '' === $this->get_price_html() && $price_html_checked ), $this );
 
 		return apply_filters( 'woocommerce_gzd_product_hide_shopmarks_empty_price', true, $this ) && $has_empty_price;
 	}


### PR DESCRIPTION
Current function is a bit buggy, some lines before you already use `get_price_html()` for child objects, should be also changed here, otherwise you still get the tax notices in woocommerce catalog shops.