### PR TITLE
fix(Compatibility, ET Builder): Added Divi 5 block support to ET Builder compatibility

### DIFF
--- a/includes/compatibility/class-wc-gzd-compatibility-et-builder.php
+++ b/includes/compatibility/class-wc-gzd-compatibility-et-builder.php
@@ -282,6 +282,13 @@ class WC_GZD_Compatibility_ET_Builder extends WC_GZD_Compatibility {
 		return $this->post_is_et_builder( $this->get_divi_builder_post(), 'checkout' );
 	}
 
+	/**
+	 * Check if the current request is a Divi 5 WooCommerce REST request.
+	 * Divi 5 uses REST API instead of AJAX, so we need to detect WooCommerce module from REST route
+	 * by checking if the request URI contains the REST URL prefix and the Divi WooCommerce module data route.
+	 *
+	 * @return bool
+	 */
 	protected function is_divi_5_woocommerce_rest_request() {
 		$is_rest_request = defined( 'REST_REQUEST' ) && REST_REQUEST;
 


### PR DESCRIPTION
Extended the Divi (ET Builder) compatibility layer to detect Divi 5 Gutenberg blocks in addition to Divi 4 shortcodes. This fixes duplicate content issues when Divi 5 WooCommerce checkout modules are used.

The existing compatibility detection only checked for Divi 4 shortcodes (et_pb_wc_checkout_*) but failed to detect Divi 5 blocks (divi/woocommerce-checkout-*), causing the WC_GZD_DISABLE_CHECKOUT_ADJUSTMENTS constant to not be set. This resulted in Germanized's checkout adjustments remaining active and causing duplicate content.

Changes made:
- Added block detection in post_is_et_builder() method using WordPress has_block() function to detect Divi 5 checkout blocks
- Created is_divi_5_woocommerce_rest_request() helper method to centralize REST API detection logic for Divi 5 WooCommerce module requests
- Updated get_divi_builder_post() to handle Divi 5 REST API requests by using DynamicAssetsUtils::get_current_post_id() for Visual Builder contexts
- Updated woocommerce_gzd_disabled_checkout_adjustments callback to handle Divi 5 REST API requests with module-specific hook restoration based on REST route detection, only restoring hooks for modules that need them (checkout_order_details and checkout_payment_info)

All changes maintain backward compatibility with Divi 4 shortcodes and AJAX requests. The solution follows Germanized's existing compatibility patterns and uses its hook priority system.

ref: https://github.com/elegantthemes/Divi/issues/46299