### PR TITLE
Rewrite product attribute helper using new filter

### DIFF
--- a/includes/abstracts/abstract-wc-gzd-product.php
+++ b/includes/abstracts/abstract-wc-gzd-product.php
@@ -1415,9 +1415,17 @@ class WC_GZD_Product {
 		return false;
 	}
 
-	protected function attribute_is_checkout_visible( $attribute ) {
-		return ( $attribute && ( 'yes' === get_option( 'woocommerce_gzd_display_checkout_product_attributes' ) || $attribute->is_checkout_visible() ) );
-	}
+    protected function attribute_is_checkout_visible( $attribute ) {
+        if ( ! $attribute ) {
+            return false;
+        }
+
+        if  ( 'yes' === get_option( 'woocommerce_gzd_display_checkout_product_attributes' ) ) {
+            return true;
+        }
+
+        return is_a( $attribute, 'WC_GZD_Product_Attribute' ) ? $attribute->is_checkout_visible() : $attribute->get_extra_data( 'checkout_visible' );
+    }
 
 	public function get_checkout_attributes( $item_data = array(), $cart_variation_data = array() ) {
 		$item_data = ! empty( $item_data ) ? $item_data : array();
@@ -1461,8 +1469,6 @@ class WC_GZD_Product {
 		$attributes = $product->get_attributes();
 
 		foreach ( $attributes as $attribute ) {
-			$attribute = WC_GZD_Product_Attribute_Helper::instance()->get_attribute( $attribute, $product );
-
 			if ( $this->attribute_is_checkout_visible( $attribute ) ) {
 				$values = array();
 

--- a/includes/class-wc-gzd-deprecated-product-attribute-helper.php
+++ b/includes/class-wc-gzd-deprecated-product-attribute-helper.php
@@ -1,0 +1,231 @@
+<?php
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Product Attribute Helper
+ *
+ *
+ * @class    WC_GZD_Deprecated_Product_Attribute_Helper
+ * @category Class
+ * @author   vendidero
+ * @deprecated
+ */
+class WC_GZD_Deprecated_Product_Attribute_Helper {
+
+	protected static $_instance = null;
+
+	public static function instance() {
+		if ( is_null( self::$_instance ) ) {
+			self::$_instance = new self();
+		}
+
+		return self::$_instance;
+	}
+
+	/**
+	 * Cloning is forbidden.
+	 *
+	 * @since 1.0
+	 */
+	public function __clone() {
+		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheating huh?', 'woocommerce-germanized' ), '1.0' );
+	}
+
+	/**
+	 * Unserializing instances of this class is forbidden.
+	 *
+	 * @since 1.0
+	 */
+	public function __wakeup() {
+		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheating huh?', 'woocommerce-germanized' ), '1.0' );
+	}
+
+	public function __construct() {
+		// Make sure Woo uses our implementation when updating the attributes via AJAX
+		add_filter( 'woocommerce_admin_meta_boxes_prepare_attribute', array( $this, 'prepare_attributes_filter' ), 10, 3 );
+
+		// Prevent losing data on saves
+		add_filter( 'update_post_metadata', array( $this, 'prevent_meta_data_override' ), 10, 5 );
+
+		// This is the only nice way to update attributes after Woo has updated product attributes
+		add_action( 'woocommerce_product_object_updated_props', array( $this, 'update_attributes' ), 10 );
+
+		// Adjust cart item data to include attributes visible during cart/checkout
+		add_filter( 'woocommerce_get_item_data', array( $this, 'cart_item_data_filter' ), 150, 2 );
+
+		if ( is_admin() ) {
+			add_action( 'woocommerce_after_product_attribute_settings', array( $this, 'attribute_visibility' ), 10, 2 );
+		}
+	}
+
+	/**
+	 * Use this tweak to prevent overriding existing checkout_visibility in case
+	 * product data is being updated without visibility data.
+	 *
+	 * @param null|bool $result
+	 * @param $object_id
+	 * @param $meta_key
+	 * @param $meta_value
+	 * @param $prev_value
+	 *
+	 * @return null|false
+	 */
+	public function prevent_meta_data_override( $result, $object_id, $meta_key, $meta_value, $prev_value ) {
+		if ( '_product_attributes' === $meta_key ) {
+			if ( is_array( $meta_value ) ) {
+				$tmp_result = null;
+
+				/**
+				 * Check whether we need to update checkout_visible with
+				 * existing (prev) data.
+				 */
+				foreach ( $meta_value as $attribute_key => $value ) {
+					if ( ! isset( $value['checkout_visible'] ) ) {
+						$tmp_result = false;
+						break;
+					}
+				}
+
+				if ( false === $tmp_result ) {
+					foreach ( $meta_value as $attribute_key => $value ) {
+						if ( ! isset( $value['checkout_visible'] ) && is_array( $meta_value[ $attribute_key ] ) ) {
+							$attribute           = new WC_GZD_Product_Attribute();
+							$is_checkout_visible = $attribute->is_checkout_visible();
+
+							if ( isset( $prev_value[ $attribute_key ] ) && $prev_value[ $attribute_key ]['checkout_visible'] ) {
+								$is_checkout_visible = $prev_value[ $attribute_key ]['checkout_visible'];
+							}
+
+							$meta_value[ $attribute_key ]['checkout_visible'] = $is_checkout_visible;
+						}
+					}
+
+					update_post_meta( $object_id, $meta_key, $meta_value );
+
+					return $tmp_result;
+				}
+			}
+		}
+
+		return $result;
+	}
+
+	public function attribute_visibility( $attribute, $i ) {
+		global $product_object, $product;
+
+		if ( isset( $product_object ) ) {
+			$gzd_product = $product_object;
+		} elseif ( isset( $product ) ) {
+			$gzd_product = $product;
+		} else {
+			$gzd_product = null;
+		}
+
+		$gzd_product_attribute = ( is_a( $attribute, 'WC_GZD_Product_Attribute' ) ? $attribute : $this->get_attribute( $attribute, $gzd_product ) );
+		?>
+		<tr>
+			<td>
+				<label><input type="checkbox" class="checkbox" <?php checked( $gzd_product_attribute->is_checkout_visible(), true ); ?>name="attribute_checkout_visibility[<?php echo esc_attr( $i ); ?>]" value="1"/> <?php esc_html_e( 'Visible during checkout', 'woocommerce-germanized' ); ?></label>
+			</td>
+		</tr>
+		<?php
+	}
+
+	public function cart_item_data_filter( $item_data, $cart_item ) {
+		$cart_product = $cart_item['data'];
+
+		if ( ! $cart_product || null === $item_data ) {
+			return $item_data;
+		}
+
+		$item_data_product = wc_gzd_get_gzd_product( $cart_product )->get_checkout_attributes( $item_data, isset( $cart_item['variation'] ) ? $cart_item['variation'] : array() );
+
+		if ( $item_data !== $item_data_product ) {
+			$item_data = array_replace_recursive( $item_data, $item_data_product );
+		}
+
+		return $item_data;
+	}
+
+	public function get_attribute_by_variation( $product, $name ) {
+		$name = str_replace( 'attribute_', '', $name );
+
+		if ( $parent = wc_get_product( $product->get_parent_id() ) ) {
+			foreach ( $parent->get_attributes() as $key => $attribute ) {
+				if ( $attribute->get_name() === $name ) {
+					return $this->get_attribute( $attribute, $parent );
+				}
+			}
+		}
+
+		return false;
+	}
+
+	public function update_attributes( $product ) {
+		$attributes = $product->get_attributes();
+		$meta       = get_post_meta( $product->get_id(), '_product_attributes', true );
+
+		if ( $meta && is_array( $meta ) ) {
+			foreach ( $meta as $meta_key => $meta_attribute ) {
+				if ( isset( $attributes[ $meta_key ] ) ) {
+					$attribute = $attributes[ $meta_key ];
+
+					if ( is_a( $attribute, 'WC_GZD_Product_Attribute' ) ) {
+						$meta[ $meta_key ]['checkout_visible'] = $attribute->get_checkout_visible() ? 1 : 0;
+					}
+				}
+			}
+
+			update_post_meta( $product->get_id(), '_product_attributes', $meta );
+		}
+	}
+
+	public function prepare_attributes_filter( $attribute, $data, $i ) {
+		$attribute_checkout_visibility = isset( $data['attribute_checkout_visibility'] ) ? $data['attribute_checkout_visibility'] : array();
+
+		$attribute = new WC_GZD_Product_Attribute( $attribute );
+		$attribute->set_checkout_visible( isset( $attribute_checkout_visibility[ $i ] ) );
+
+		return $attribute;
+	}
+
+	protected function get_product_id( $maybe_product_id ) {
+		$product_id = false;
+
+		if ( is_numeric( $maybe_product_id ) ) {
+			$product_id = $maybe_product_id;
+		} elseif ( is_a( $maybe_product_id, 'WC_Product' ) || is_a( $maybe_product_id, 'WC_GZD_Product' ) ) {
+			$product_id = $maybe_product_id->get_id();
+		}
+
+		return $product_id;
+	}
+
+	public function get_attribute( $attribute, $product_id = false ) {
+		$new_attribute   = new WC_GZD_Product_Attribute( $attribute );
+		$product_id      = $this->get_product_id( $product_id );
+		$meta_attributes = $product_id ? get_post_meta( $product_id, '_product_attributes', true ) : array();
+		$meta_key        = sanitize_title( $new_attribute->get_name() );
+
+		if ( ! empty( $meta_attributes ) && is_array( $meta_attributes ) ) {
+			if ( isset( $meta_attributes[ $meta_key ] ) ) {
+				$meta_value = array_merge(
+					array(
+						/** This filter is documented in includes/class-wc-gzd-product-attribute.php */
+						'checkout_visible' => apply_filters( 'woocommerce_gzd_product_attribute_checkout_visible_default_value', false ),
+					),
+					(array) $meta_attributes[ $meta_key ]
+				);
+
+				if ( ! is_null( $meta_value['checkout_visible'] ) ) {
+					$new_attribute->set_checkout_visible( $meta_value['checkout_visible'] );
+				}
+			}
+		}
+
+		return $new_attribute;
+	}
+}
+
+WC_GZD_Product_Attribute_Helper::instance();

--- a/includes/class-wc-gzd-product-attribute-helper.php
+++ b/includes/class-wc-gzd-product-attribute-helper.php
@@ -7,6 +7,10 @@ class WC_GZD_Product_Attribute_Helper {
 	protected static $_instance = null;
 
 	public static function instance() {
+        if ( defined( 'WC_VERSION' ) && version_compare( WC_VERSION, '10.6.0', '<' ) ) {
+            return WC_GZD_Deprecated_Product_Attribute_Helper::instance();
+        }
+
 		if ( is_null( self::$_instance ) ) {
 			self::$_instance = new self();
 		}
@@ -34,90 +38,41 @@ class WC_GZD_Product_Attribute_Helper {
 
 	public function __construct() {
 		// Make sure Woo uses our implementation when updating the attributes via AJAX
-		add_filter( 'woocommerce_admin_meta_boxes_prepare_attribute', array( $this, 'prepare_attributes_filter' ), 10, 3 );
+        add_filter( 'woocommerce_product_read_attribute', array( $this, 'read' ), 10, 2 );
+        add_filter( 'woocommerce_product_importer_read_attribute', array( $this, 'read' ), 10, 2 );
 
-		// Prevent losing data on saves
-		add_filter( 'update_post_metadata', array( $this, 'prevent_meta_data_override' ), 10, 5 );
-
-		// This is the only nice way to update attributes after Woo has updated product attributes
-		add_action( 'woocommerce_product_object_updated_props', array( $this, 'update_attributes' ), 10 );
+		// Save additional attribute data
+		add_filter( 'woocommerce_admin_meta_boxes_prepare_attribute', array( $this, 'save' ), 10, 3 );
 
 		// Adjust cart item data to include attributes visible during cart/checkout
 		add_filter( 'woocommerce_get_item_data', array( $this, 'cart_item_data_filter' ), 150, 2 );
 
 		if ( is_admin() ) {
-			add_action( 'woocommerce_after_product_attribute_settings', array( $this, 'attribute_visibility' ), 10, 2 );
+			add_action( 'woocommerce_after_product_attribute_settings', array( $this, 'edit' ), 10, 2 );
 		}
 	}
 
-	/**
-	 * Use this tweak to prevent overriding existing checkout_visibility in case
-	 * product data is being updated without visibility data.
-	 *
-	 * @param null|bool $result
-	 * @param $object_id
-	 * @param $meta_key
-	 * @param $meta_value
-	 * @param $prev_value
-	 *
-	 * @return null|false
-	 */
-	public function prevent_meta_data_override( $result, $object_id, $meta_key, $meta_value, $prev_value ) {
-		if ( '_product_attributes' === $meta_key ) {
-			if ( is_array( $meta_value ) ) {
-				$tmp_result = null;
+	public function read( WC_Product_Attribute $attribute, $data ) {
+        $default_checkout_visible = apply_filters( 'woocommerce_gzd_product_attribute_checkout_visible_default_value', false );
 
-				/**
-				 * Check whether we need to update checkout_visible with
-				 * existing (prev) data.
-				 */
-				foreach ( $meta_value as $attribute_key => $value ) {
-					if ( ! isset( $value['checkout_visible'] ) ) {
-						$tmp_result = false;
-						break;
-					}
-				}
+		$attribute->set_extra_data( 'checkout_visible', isset( $data['checkout_visible'] ) ? $data['checkout_visible'] : $default_checkout_visible);
 
-				if ( false === $tmp_result ) {
-					foreach ( $meta_value as $attribute_key => $value ) {
-						if ( ! isset( $value['checkout_visible'] ) && is_array( $meta_value[ $attribute_key ] ) ) {
-							$attribute           = new WC_GZD_Product_Attribute();
-							$is_checkout_visible = $attribute->is_checkout_visible();
-
-							if ( isset( $prev_value[ $attribute_key ] ) && $prev_value[ $attribute_key ]['checkout_visible'] ) {
-								$is_checkout_visible = $prev_value[ $attribute_key ]['checkout_visible'];
-							}
-
-							$meta_value[ $attribute_key ]['checkout_visible'] = $is_checkout_visible;
-						}
-					}
-
-					update_post_meta( $object_id, $meta_key, $meta_value );
-
-					return $tmp_result;
-				}
-			}
-		}
-
-		return $result;
+		return $attribute;
 	}
 
-	public function attribute_visibility( $attribute, $i ) {
-		global $product_object, $product;
+	public function save( WC_Product_Attribute $attribute, $data, $i ) {
+		$attribute_checkout_visibility = isset( $data['attribute_checkout_visibility'][$i] ) && $data['attribute_checkout_visibility'][$i];
 
-		if ( isset( $product_object ) ) {
-			$gzd_product = $product_object;
-		} elseif ( isset( $product ) ) {
-			$gzd_product = $product;
-		} else {
-			$gzd_product = null;
-		}
+		$attribute->set_extra_data( 'checkout_visible', $attribute_checkout_visibility );
 
-		$gzd_product_attribute = ( is_a( $attribute, 'WC_GZD_Product_Attribute' ) ? $attribute : $this->get_attribute( $attribute, $gzd_product ) );
+		return $attribute;
+	}
+
+	public function edit( $attribute, $i ) {
 		?>
 		<tr>
 			<td>
-				<label><input type="checkbox" class="checkbox" <?php checked( $gzd_product_attribute->is_checkout_visible(), true ); ?>name="attribute_checkout_visibility[<?php echo esc_attr( $i ); ?>]" value="1"/> <?php esc_html_e( 'Visible during checkout', 'woocommerce-germanized' ); ?></label>
+				<label><input type="checkbox" class="checkbox" <?php checked( $attribute->get_extra_data( 'checkout_visible' ), true ); ?>name="attribute_checkout_visibility[<?php echo esc_attr( $i ); ?>]" value="1"/> <?php esc_html_e( 'Visible during checkout', 'woocommerce-germanized' ); ?></label>
 			</td>
 		</tr>
 		<?php
@@ -145,40 +100,12 @@ class WC_GZD_Product_Attribute_Helper {
 		if ( $parent = wc_get_product( $product->get_parent_id() ) ) {
 			foreach ( $parent->get_attributes() as $key => $attribute ) {
 				if ( $attribute->get_name() === $name ) {
-					return $this->get_attribute( $attribute, $parent );
+					return $attribute;
 				}
 			}
 		}
 
 		return false;
-	}
-
-	public function update_attributes( $product ) {
-		$attributes = $product->get_attributes();
-		$meta       = get_post_meta( $product->get_id(), '_product_attributes', true );
-
-		if ( $meta && is_array( $meta ) ) {
-			foreach ( $meta as $meta_key => $meta_attribute ) {
-				if ( isset( $attributes[ $meta_key ] ) ) {
-					$attribute = $attributes[ $meta_key ];
-
-					if ( is_a( $attribute, 'WC_GZD_Product_Attribute' ) ) {
-						$meta[ $meta_key ]['checkout_visible'] = $attribute->get_checkout_visible() ? 1 : 0;
-					}
-				}
-			}
-
-			update_post_meta( $product->get_id(), '_product_attributes', $meta );
-		}
-	}
-
-	public function prepare_attributes_filter( $attribute, $data, $i ) {
-		$attribute_checkout_visibility = isset( $data['attribute_checkout_visibility'] ) ? $data['attribute_checkout_visibility'] : array();
-
-		$attribute = new WC_GZD_Product_Attribute( $attribute );
-		$attribute->set_checkout_visible( isset( $attribute_checkout_visibility[ $i ] ) );
-
-		return $attribute;
 	}
 
 	protected function get_product_id( $maybe_product_id ) {
@@ -191,31 +118,6 @@ class WC_GZD_Product_Attribute_Helper {
 		}
 
 		return $product_id;
-	}
-
-	public function get_attribute( $attribute, $product_id = false ) {
-		$new_attribute   = new WC_GZD_Product_Attribute( $attribute );
-		$product_id      = $this->get_product_id( $product_id );
-		$meta_attributes = $product_id ? get_post_meta( $product_id, '_product_attributes', true ) : array();
-		$meta_key        = sanitize_title( $new_attribute->get_name() );
-
-		if ( ! empty( $meta_attributes ) && is_array( $meta_attributes ) ) {
-			if ( isset( $meta_attributes[ $meta_key ] ) ) {
-				$meta_value = array_merge(
-					array(
-						/** This filter is documented in includes/class-wc-gzd-product-attribute.php */
-						'checkout_visible' => apply_filters( 'woocommerce_gzd_product_attribute_checkout_visible_default_value', false ),
-					),
-					(array) $meta_attributes[ $meta_key ]
-				);
-
-				if ( ! is_null( $meta_value['checkout_visible'] ) ) {
-					$new_attribute->set_checkout_visible( $meta_value['checkout_visible'] );
-				}
-			}
-		}
-
-		return $new_attribute;
 	}
 }
 

--- a/includes/export/class-wc-gzd-product-export.php
+++ b/includes/export/class-wc-gzd-product-export.php
@@ -224,9 +224,9 @@ class WC_GZD_Product_Export {
 					$this->additional_columns[ 'attributes:checkout_visible' . $i ] = sprintf( __( 'Attribute %d checkout visible', 'woocommerce-germanized' ), $i );
 
 					if ( is_a( $attribute, 'WC_Product_Attribute' ) ) {
-						if ( $gzd_attribute = WC_GZD_Product_Attribute_Helper::instance()->get_attribute( $attribute, $product ) ) {
-							$row[ 'attributes:checkout_visible' . $i ] = $gzd_attribute->get_checkout_visible();
-						}
+                        $row[ 'attributes:checkout_visible' . $i ] = method_exists( $attribute, 'get_extra_data' ) ?
+                            $attribute->get_extra_data( 'checkout_visible' ) :
+                            WC_GZD_Product_Attribute_Helper::instance()->get_attribute( $attribute, $product )->get_checkout_visible();
 					} else {
 						$row[ 'attributes:checkout_visible' . $i ] = 0;
 					}

--- a/woocommerce-germanized.php
+++ b/woocommerce-germanized.php
@@ -639,7 +639,8 @@ if ( ! class_exists( 'WooCommerce_Germanized' ) ) :
 
 			// Product Attribute
 			include_once WC_GERMANIZED_ABSPATH . 'includes/class-wc-gzd-product-attribute.php';
-			include_once WC_GERMANIZED_ABSPATH . 'includes/class-wc-gzd-product-attribute-helper.php';
+            include_once WC_GERMANIZED_ABSPATH . 'includes/class-wc-gzd-product-attribute-helper.php';
+            include_once WC_GERMANIZED_ABSPATH . 'includes/class-wc-gzd-deprecated-product-attribute-helper.php';
 
 			include_once WC_GERMANIZED_ABSPATH . 'includes/class-wc-gzd-voucher-discounts.php';
 


### PR DESCRIPTION
After following woocommerce PR (https://github.com/woocommerce/woocommerce/pull/62572) it's "now" (in WC >= `10.6`)  easier to update product attributes.

So thx for your crazy workaround here, but following quote in your code is (happily) no longer valid :D
> // This is the only nice way to update attributes after Woo has updated product attributes

#### TODO

The helper class includes following function `get_attribute()`, which is using `WC_GZD_Product_Attribute`, I'm not sure if it's possible to remove this part without breaking anything. In my opinion the whole `WC_GZD_Product_Attribute` class should be removed (also used somewhere in importer script).

PS: WC `10.6` is still not released & this would also break compatibility with instances updating germanized but not woocommerce. So we may should wait a while before merging... :'D