### PR TITLE
fix(Order): avoid split tax meta for non-taxable fees and warn about fee tax status

### DIFF
--- a/includes/admin/settings/class-wc-gzd-settings-tab-taxes.php
+++ b/includes/admin/settings/class-wc-gzd-settings-tab-taxes.php
@@ -45,6 +45,25 @@ class WC_GZD_Settings_Tab_Taxes extends WC_GZD_Settings_Tab {
 		return 'https://vendidero.de/doc/woocommerce-germanized/steuerberechnung-fuer-versandkosten-und-gebuehren';
 	}
 
+	protected function get_additional_costs_fee_settings_url() {
+		if ( \Vendidero\Germanized\PluginsHelper::is_plugin_active( 'checkout-fees-for-woocommerce-pro' ) || \Vendidero\Germanized\PluginsHelper::is_plugin_active( 'checkout-fees-for-woocommerce' ) ) {
+			return admin_url( 'admin.php?page=wc-settings&tab=alg_checkout_fees' );
+		}
+
+		return false;
+	}
+
+	protected function get_additional_costs_non_taxable_fee_notice() {
+		$fee_settings_url = $this->get_additional_costs_fee_settings_url();
+		$notice_text      = __( 'When using a Germanized tax mode for additional costs, make sure that payment surcharges and similar fees use the correct tax status. Fees stored as non-taxable may otherwise lead to mixed tax data and document creation issues.', 'woocommerce-germanized' );
+
+		if ( $fee_settings_url ) {
+			$notice_text .= ' ' . sprintf( __( 'If you are using payment gateway based fees, please review the tax settings within your <a href="%s">fee configuration</a>.', 'woocommerce-germanized' ), esc_url( $fee_settings_url ) );
+		}
+
+		return '<div class="notice inline notice-warning"><p>' . wp_kses_post( $notice_text ) . '</p></div>';
+	}
+
 	protected function get_vat_settings() {
 		$virtual_vat = 'yes' !== get_option( 'woocommerce_gzd_enable_virtual_vat' ) ? array() : array(
 			'title'   => __( 'Virtual VAT', 'woocommerce-germanized' ),
@@ -141,6 +160,12 @@ class WC_GZD_Settings_Tab_Taxes extends WC_GZD_Settings_Tab {
 					'split_tax'    => __( 'Proportionate', 'woocommerce-germanized' ),
 					'main_service' => __( 'Based on main service', 'woocommerce-germanized' ),
 				),
+			),
+			array(
+				'title' => '',
+				'id'    => 'woocommerce_gzd_tax_mode_additional_costs_non_taxable_fee_notice',
+				'type'  => 'html',
+				'html'  => $this->get_additional_costs_non_taxable_fee_notice(),
 			),
 
 			array(

--- a/includes/class-wc-gzd-order-helper.php
+++ b/includes/class-wc-gzd-order-helper.php
@@ -337,13 +337,44 @@ class WC_GZD_Order_Helper {
 		$item->delete_meta_data( '_tax_shares' );
 
 		if ( $order = $item->get_order() ) {
-			$order->delete_meta_data( '_has_split_tax' );
 			$order->delete_meta_data( '_additional_costs_include_tax' );
 			$order->delete_meta_data( '_additional_costs_taxed_based_on_main_service' );
 			$order->delete_meta_data( '_additional_costs_taxed_based_on_main_service_tax_class' );
 			$order->delete_meta_data( '_additional_costs_taxed_based_on_main_service_by' );
+			$this->sync_order_split_tax_meta( $order );
 
 			$order->save();
+		}
+	}
+
+	/**
+	 * @param WC_Order_Item $item
+	 *
+	 * @return bool
+	 */
+	protected function item_supports_split_tax_meta( $item ) {
+		return ! is_a( $item, 'WC_Order_Item_Fee' ) || 'taxable' === $item->get_tax_status();
+	}
+
+	/**
+	 * @param WC_Order $order
+	 *
+	 * @return void
+	 */
+	protected function sync_order_split_tax_meta( $order ) {
+		$has_split_tax = false;
+
+		foreach ( $order->get_items( array( 'shipping', 'fee' ) ) as $additional_cost ) {
+			if ( ! empty( $additional_cost->get_meta( '_split_taxes', true ) ) ) {
+				$has_split_tax = true;
+				break;
+			}
+		}
+
+		if ( $has_split_tax ) {
+			$order->update_meta_data( '_has_split_tax', 'yes' );
+		} else {
+			$order->delete_meta_data( '_has_split_tax' );
 		}
 	}
 
@@ -396,10 +427,14 @@ class WC_GZD_Order_Helper {
 			$item->delete_meta_data( '_split_taxes' );
 			$item->delete_meta_data( '_tax_shares' );
 
-			$order->delete_meta_data( '_has_split_tax' );
 			$order->delete_meta_data( '_additional_costs_taxed_based_on_main_service' );
 			$order->delete_meta_data( '_additional_costs_taxed_based_on_main_service_tax_class' );
 			$order->delete_meta_data( '_additional_costs_taxed_based_on_main_service_by' );
+			$this->sync_order_split_tax_meta( $order );
+
+			if ( ! $this->item_supports_split_tax_meta( $item ) ) {
+				return;
+			}
 
 			$calculate_tax_for = empty( $calculate_tax_for ) ? $this->get_order_taxable_location( $order ) : $calculate_tax_for;
 			$tax_type          = 'shipping' === $item->get_type() ? 'shipping' : 'fee';
@@ -451,14 +486,11 @@ class WC_GZD_Order_Helper {
 					if ( wc_gzd_additional_costs_include_tax() ) {
 						$item->set_total( $item_total - $item->get_total_tax() );
 					}
-
-					$order->update_meta_data( '_has_split_tax', 'yes' );
 				} else {
 					$item->delete_meta_data( '_split_taxes' );
 					$item->delete_meta_data( '_tax_shares' );
-
-					$order->delete_meta_data( '_has_split_tax' );
 				}
+				$this->sync_order_split_tax_meta( $order );
 			} elseif ( wc_gzd_calculate_additional_costs_taxes_based_on_main_service() ) {
 				$taxes          = array();
 				$main_tax_class = self::instance()->get_order_main_service_tax_class( $order, $tax_type );
@@ -693,6 +725,10 @@ class WC_GZD_Order_Helper {
 	 * @param WC_Order $order
 	 */
 	public function set_fee_split_tax_meta( $item, $fee_key, $fee, $order ) {
+		if ( ! $this->item_supports_split_tax_meta( $item ) ) {
+			return;
+		}
+
 		if ( isset( $fee->split_taxes ) && ! empty( $fee->split_taxes ) ) {
 			$item->update_meta_data( '_split_taxes', $fee->split_taxes );
 		}

--- a/tests/unit-tests/order/fees.php
+++ b/tests/unit-tests/order/fees.php
@@ -1,0 +1,101 @@
+<?php
+
+class WC_GZD_Tests_Order_Fees extends WC_GZD_Unit_Test_Case {
+
+	function test_non_taxable_fee_does_not_store_split_tax_meta_during_checkout() {
+		$order = new WC_Order();
+		$fee   = new WC_Order_Item_Fee();
+
+		$fee->set_props(
+			array(
+				'name'       => 'Payment fee',
+				'total'      => 10.00,
+				'tax_status' => 'none',
+			)
+		);
+
+		$order->add_item( $fee );
+
+		$cart_fee = (object) array(
+			'split_taxes' => array(
+				'' => array(
+					'taxable_amount' => 10.00,
+					'tax_share'      => 1,
+					'tax_rates'      => array( 1 ),
+					'net_amount'     => 8.40,
+					'includes_tax'   => true,
+				),
+			),
+		);
+
+		WC_GZD_Order_Helper::instance()->set_fee_split_tax_meta( $fee, 'payment-fee', $cart_fee, $order );
+
+		$this->assertEmpty( $fee->get_meta( '_split_taxes', true ) );
+	}
+
+	function test_non_taxable_fee_removes_existing_split_tax_meta_on_recalculation() {
+		$previous_mode = get_option( 'woocommerce_gzd_tax_mode_additional_costs', 'main_service' );
+
+		try {
+			update_option( 'woocommerce_gzd_tax_mode_additional_costs', 'split_tax' );
+
+			$order = WC_GZD_Helper_Order::create_billing_order(
+				true,
+				array(
+					array(
+						'type'     => 'line_item',
+						'quantity' => 1,
+						'subtotal' => 100.00,
+						'total'    => 100.00,
+					),
+					array(
+						'type'       => 'fee',
+						'name'       => 'Payment fee',
+						'total'      => 10.00,
+						'tax_status' => 'none',
+					),
+				)
+			);
+
+			$fee = current( $order->get_fees() );
+
+			$fee->update_meta_data(
+				'_split_taxes',
+				array(
+					'' => array(
+						'taxable_amount' => 10.00,
+						'tax_share'      => 1,
+						'tax_rates'      => array( 1 ),
+						'net_amount'     => 8.40,
+						'includes_tax'   => true,
+					),
+				)
+			);
+			$fee->update_meta_data(
+				'_tax_shares',
+				array(
+					'' => array(
+						'total' => 10.00,
+						'key'   => '1',
+						'share' => 1,
+					),
+				)
+			);
+			$fee->save();
+
+			$order->calculate_totals();
+			$order->save();
+
+			$order = wc_get_order( $order->get_id() );
+			$fee   = current( $order->get_fees() );
+
+			$this->assertEquals( 'none', $fee->get_tax_status() );
+			$this->assertEquals( '0.00', wc_format_decimal( $fee->get_total_tax(), '' ) );
+			$this->assertEmpty( $fee->get_meta( '_split_taxes', true ) );
+			$this->assertEmpty( $fee->get_meta( '_tax_shares', true ) );
+			$this->assertEmpty( $order->get_meta( '_has_split_tax', true ) );
+		} finally {
+			update_option( 'woocommerce_gzd_tax_mode_additional_costs', $previous_mode );
+		}
+	}
+}


### PR DESCRIPTION
# Title

fix(Order): avoid split tax meta for non-taxable fees and warn about fee tax status

# Summary

This PR prevents Germanized from persisting split-tax metadata for fee items that are explicitly stored as non-taxable and adds an admin warning for a common misconfiguration in additional-cost tax handling.

The patch does two things:

1. It skips split-tax persistence and recalculation for non-taxable fee items.
2. It adds a warning in `Germanized > Taxes > Additional Costs` so shop admins are less likely to end up with contradictory fee tax data.

# Problem

In a real-world WooCommerce + Germanized setup, a payment surcharge was stored on the order as:

- `tax_status = none`
- `total_tax = 0`

but the fee still contained Germanized split-tax metadata:

- `_split_taxes`
- `_tax_shares`

That creates contradictory order-item data:

- the fee itself is non-taxable
- the additional-cost metadata still distributes the fee across taxable rates

Downstream consumers can then interpret the fee as taxable and derive phantom tax amounts from the split-tax metadata.

# Root Cause

Germanized currently persists and recalculates additional-cost split-tax metadata without checking whether a fee item is explicitly stored as non-taxable on the order item itself.

As a result:

- checkout-created fee items may retain `_split_taxes` even though the fee is non-taxable
- recalculation flows may recreate `_split_taxes` / `_tax_shares` for such fees
- order-level `_has_split_tax` can drift when fee/shipping metadata changes item-by-item

# Changes

- Skip fee split-tax metadata persistence during checkout when the fee item is non-taxable.
- Keep split-tax metadata cleared during recalculation for non-taxable fee items.
- Synchronize the order-level `_has_split_tax` flag from actual persisted split-tax metadata on shipping and fee items.
- Add an admin warning in the Additional Costs settings explaining that payment surcharges and similar fees should use the correct tax status.
- Add a direct link to the fee settings page if `checkout-fees-for-woocommerce-pro` (or its free variant) is active.

# Scope

This PR focuses on the public Germanized side of the issue:

- preventing contradictory split-tax metadata from being created for non-taxable fees
- surfacing the misconfiguration earlier in the admin

Legacy orders may still need a one-time data cleanup if inconsistent fee tax data already exists in historical orders.

# Verification

- `php -l includes/class-wc-gzd-order-helper.php`
- `php -l includes/admin/settings/class-wc-gzd-settings-tab-taxes.php`
- `php -l tests/unit-tests/order/fees.php`
- `./vendor/bin/phpcs --standard=phpcs.xml includes/admin/settings/class-wc-gzd-settings-tab-taxes.php includes/class-wc-gzd-order-helper.php tests/unit-tests/order/fees.php`
- validated against a staging WooCommerce shop with a real-world reproduction:
  - a historical order with a non-taxable payment surcharge and contradictory additional-cost metadata could not be invoiced until the stale fee metadata was cleaned
  - a new test order created after correcting the surcharge tax status could be invoiced successfully through the normal admin sync action
  - older already-finalized invoice orders kept their totals and finalized document state after re-saving with the cleanup logic in place

# Tests

Added `tests/unit-tests/order/fees.php` with coverage for:

- non-taxable checkout fee items not storing split-tax metadata
- stale split-tax metadata being removed from non-taxable fee items during recalculation

I could not run the full PHPUnit suite locally because the repository's WordPress/WooCommerce test stack is not available in this environment, but the new test file is included and PHPCS passes.
